### PR TITLE
Fix reading whitelist from environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var app = require('./lib/proxy')();
 
 var port = process.env.PORT || 5000;
-var whitelist = process.env.WHITELIST || []; // [/\.gov$/, /google\.com$/]
 app.listen(port, function () {
   console.log('Listening on ' + port);
 });

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -10,7 +10,7 @@ var express = require('express')
   // @see http://aaronheckmann.posterous.com/graphicsmagick-on-heroku-with-nodejs
   , imageMagick = gm.subClass({imageMagick: true})
   , app = express.createServer(express.logger())
-  , whitelist = []
+  , whitelist = process.env.WHITELIST || [] // [/\.gov$/, /google\.com$/]
   , mimeTypes = [
     'image/jpeg',
     'image/png',


### PR DESCRIPTION
Restores the ability to provide a `WHITELIST` environment variable, which was accidentally broken in #6.
