### PR TITLE
Send an 'Accept' header in the image request

### DIFF
--- a/lib/image-proxy.js
+++ b/lib/image-proxy.js
@@ -37,7 +37,7 @@ module.exports = function () {
         if (!options.hostname) {
           return res.status(404).send('Expected URI host to be non-empty');
         }
-        options.headers = {'User-Agent': 'image-proxy/0.0.6'}
+        options.headers = {'User-Agent': 'image-proxy/0.0.6', 'Accept': 'image/*'};
 
         var agent = options.protocol === 'http:' ? http : https
           , timeout = false

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,19 @@ function server(req, res) {
     });
     res.end(png, 'binary');
   }
+  else if (path === '/error-without-accept-header') {
+    if (req.headers['accept']) {
+      res.writeHead(200, {
+        'Content-Type': 'image/png'
+      });
+      res.end(png, 'binary');
+    } else {
+      res.writeHead(403, {
+        'Location': '/test.png'
+      });
+      res.end();
+    }
+  }
   else {
     res.writeHead(500);
     res.end(path);
@@ -232,6 +245,12 @@ describe('GET /:url/:width/:height.:extension?', function () {
       .get('/https%3A%2F%2Flocalhost:8081%2Ftest.png/100/100')
       .expect('Content-Type', 'image/png')
       .expect('Cache-Control', 'max-age=31536000, public')
+      .expect(200, done);
+  });
+
+  it('sends an accept header in the request', function (done) {
+    request(app)
+      .get('/https%3A%2F%2Flocalhost:8081%2Ferror-without-accept-header/100/100')
       .expect(200, done);
   });
 });


### PR DESCRIPTION
Some urls, e.g. this one - http://www.congreso.gob.gt/manager/images/69DBC2D6-2EE6-3EA7-411F-07C91997560D.jpg, don't respond correctly if there's no `Accept` header in the request.

https://everypolitician-image-proxy.herokuapp.com/http%3A%2F%2Fwww.congreso.gob.gt%2Fmanager%2Fimages%2F69DBC2D6-2EE6-3EA7-411F-07C91997560D.jpg/140/140.jpg

This change adds an `Accept: image/*` header to each request for external images.

I'm not 100% sure that this is the correct and/or best thing to be doing, but it certainly fixes it for the specific case of images on www.congreso.gob.gt.