### PR TITLE
Convert the image if a format is specified

### DIFF
--- a/lib/image-proxy.js
+++ b/lib/image-proxy.js
@@ -93,7 +93,7 @@ module.exports = function () {
             .resize(width, height + '^>')
             .gravity('Center') // faces are most often near the center
             .extent(width, height)
-            .stream(function (err, stdout, stderr) {
+            .stream(extension, function (err, stdout, stderr) {
               if (err) return next(err);
               // Log errors in production.
               stderr.pipe(process.stderr);


### PR DESCRIPTION
Currently, if you include an 'extension' in your request, the
Content-type of the response will match that format, no matter what
image format the source image was.

However, this doesn't actually reformat the image. It just changes the
Content-type on the response headers. See #21 .

Reformatting the actual image provides more control, such as accessing
the nice image compression you get from the jpeg format.

This commit passes the 'extension' to the [.stream() function](https://github.com/aheckmann/gm#streams).
The image is then streamed back in the specified format.

If no 'extension' has been specified by the user, it falls back to the
Content-type of the source image.

Fixes #21

@jpmckinney I'm not sure how to write a test for this sorry. Also, if this isn't the intention of the proxy, feel free to close this :)