### PR TITLE
Fix Heroku config so “Deploy to Heroku” button works

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/ello/heroku-buildpack-imagemagick
-https://github.com/heroku/heroku-buildpack-nodejs

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/ello/heroku-buildpack-imagemagick-cedar-14
+https://github.com/ello/heroku-buildpack-imagemagick
 https://github.com/heroku/heroku-buildpack-nodejs

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ If you need more features, see [node-imageable](https://github.com/sdepold/node-
 
     git clone https://github.com/jpmckinney/image-proxy.git
     heroku apps:create
-    heroku config:set BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi
     heroku config:set NODE_ENV=production
     git push heroku master
     heroku apps:open

--- a/app.json
+++ b/app.json
@@ -5,7 +5,14 @@
   "keywords": ["image", "proxy"],
   "addons": [],
   "env": {
-    "BUILDPACK_URL": "https://github.com/ddollar/heroku-buildpack-multi",
     "NODE_ENV": "production"
-  }
+  },
+  "buildpacks": [
+    {
+      "url": "https://github.com/ello/heroku-buildpack-imagemagick-cedar-14"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-nodejs"
+    }
+  ]
 }

--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
   },
   "buildpacks": [
     {
-      "url": "https://github.com/ello/heroku-buildpack-imagemagick-cedar-14"
+      "url": "https://github.com/ello/heroku-buildpack-imagemagick"
     },
     {
       "url": "https://github.com/heroku/heroku-buildpack-nodejs"


### PR DESCRIPTION
As described in #20 , the deploy to Heroku button isn't working because of problems resolving ImageMagick dependencies.

I started looking at the [buildpack used for installing ImageMagik and found it was depreciated](https://github.com/ello/heroku-buildpack-imagemagick-cedar-14#deprecated).

Also, Heroku now supports using multiple buildpacks. The [buildpack-multi buildpack used here (also depreciated) using suggests trying out the build-in support](https://github.com/ddollar/heroku-buildpack-multi#deprecated).

These commits:

1. change the way buildpacks are specified to use the [configuration suggested by Heroku for their built-in multi-buildpack support](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app).

2. move to the [newer ImageMagik buildpack](https://github.com/ello/heroku-buildpack-imagemagick) [recommended by depreciated one](https://github.com/ello/heroku-buildpack-imagemagick-cedar-14#deprecated) in current use.

3. clean up references to the old buildpack configuration

I've tested that this gets the button working again [over here](https://github.com/openaustralia/image-proxy/tree/fix-heroku-buildpacks), also works for deploying from the command line locally following the instructions in the readme (fixes #20).

I'm just learning about Heroku buildpacks so please have a good look at this before merging.