### PR TITLE
Update mime lookup and extension methods for v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   # express 3.0 was released late 2012
   # gm 1.2.0 added extent and gravity
   # mime 1.1.0 added extension
-  - MODULES="express@~3 gm@1.2.0 mime@1.1.0"
+  - MODULES="express@~3 gm@1.2.0 mime@2.0.0"
   - MODULES=""
 install:
   - npm install $MODULES

--- a/lib/image-proxy.js
+++ b/lib/image-proxy.js
@@ -76,11 +76,11 @@ module.exports = function () {
             // @see http://nodejs.org/api/http.html#http_request_headers
             var mimeType;
             if (extension) {
-              mimeType = mime.lookup(extension);
+              mimeType = mime.getType(extension);
             }
             else {
               mimeType = (response.headers['content-type'] || '').replace(/;.*/, '');
-              extension = mime.extension(mimeType);
+              extension = mime.getExtension(mimeType);
             }
             if (mimeTypes.indexOf(mimeType) === -1) {
               return res.status(404).send('Expected content type ' + mimeTypes.join(', ') + ', got ' + mimeType);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "image-proxy",
   "version": "0.0.7",
   "description": "A simple image proxy optimized for headshots",
-  "keywords": ["image", "proxy"],
+  "keywords": [
+    "image",
+    "proxy"
+  ],
   "homepage": "https://github.com/jpmckinney/image-proxy",
   "bugs": "https://github.com/jpmckinney/image-proxy/issues",
   "license": "MIT",
@@ -20,7 +23,7 @@
   "dependencies": {
     "express": ">=3",
     "gm": ">=1.2.0",
-    "mime": ">=1.1.0"
+    "mime": ">=2.0.0"
   },
   "devDependencies": {
     "coveralls": "~2.11",


### PR DESCRIPTION
- `mime.lookup()` -> `mime.getType()`
- `mime.extension()` -> `mime.getExtension()`

Closes #30